### PR TITLE
fix: import qbx lib

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,9 +5,13 @@ description 'QBX_Vehicles'
 repository 'https://github.com/Qbox-project/qbx_vehicles'
 version '0.0.1'
 
+shared_scripts {
+    '@ox_lib/init.lua',
+    '@qbx_core/modules/lib.lua'
+}
+
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
-    'qbx_core/modules/lib.lua',
     'server/main.lua'
 }
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

When using the export 'GetPlayerVehicles' an error would be displayed saying it is nil. Adding the @ to '@qbx_core/modules/lib.lua' and changing the location to shared scripts fixed the issue. This is only because 'GetPlayerVehicles' is the only export that uses the lib.


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
