### PR TITLE
feat: new PlayerVehicle fields and query filtering

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -74,13 +74,12 @@ local function buildWhereClause(filters)
             filters.states = {filters.states}
         end
         if #filters.states > 0 then
-            query = query .. ' AND (1=2'
+            local statePlaceholders = {}
             for i = 1, #filters.states do
-                local state = filters.states[i]
-                query = query .. ' OR state = ?'
-                placeholders[#placeholders+1] = state
+                placeholders[#placeholders+1] = filters.states[i]
+                statePlaceholders[i] = 'state = ?'
             end
-            query = query .. ')'
+            query = query .. string.format(' AND (%s)', table.concat(statePlaceholders, ' OR '))
         end
     end
     return query, placeholders


### PR DESCRIPTION
- Adding garage, state, and depotPrice to PlayerVehicle definition to support qbx_garages 
- When creating a new vehicle, can optionally specify a starting garage now
- When fetching a vehicle from storage, the parameter is now a filter table which converts filtering options to a SQL WHERE clause. If nil, fetches all vehicles in the table. This flexibility in query filtering supports qbx_garages use cases without over fetching. The alternative would be doing post-query filtering, at the cost of a larger database read. I went with query filtering however, as I think this type of filtering would be broadly useful to many scripts.