### PR TITLE
feat: SaveVehicle export

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -249,6 +249,7 @@ local function buildSaveVehicleQuery(vehicleId, options)
     return string.format('UPDATE player_vehicles SET %s WHERE id = ?', table.concat(crumbs, ',')), placeholders
 end
 
+---@param vehicle number entity
 ---@param options SaveVehicleOptions
 ---@return boolean success, ErrorResult? errorResult
 local function saveVehicle(vehicle, options)

--- a/server/main.lua
+++ b/server/main.lua
@@ -210,3 +210,59 @@ local function getVehicleIdByPlate(plate)
 end
 
 exports('GetVehicleIdByPlate', getVehicleIdByPlate)
+
+---@class SaveVehicleOptions
+---@field garage? string
+---@field state? State
+---@field depotPrice? integer
+---@field props? table ox_lib properties table
+
+---@param vehicleId integer
+---@param options SaveVehicleOptions
+---@return string query, table placeholders
+local function buildSaveVehicleQuery(vehicleId, options)
+    local crumbs = {}
+    local placeholders = {}
+
+    if options.state then
+        crumbs[#crumbs+1] = 'state = ?'
+        placeholders[#placeholders+1] = options.state
+    end
+
+    if options.depotPrice then
+        crumbs[#crumbs+1] = 'depotprice = ?'
+        placeholders[#placeholders+1] = options.depotPrice
+    end
+
+    if options.garage then
+        crumbs[#crumbs+1] = 'garage = ?'
+        placeholders[#placeholders+1] = options.garage
+    end
+
+    if options.props then
+        crumbs[#crumbs+1] = 'mods = ?'
+        placeholders[#placeholders+1] = json.encode(options.props)
+    end
+
+    placeholders[#placeholders+1] = vehicleId
+
+    return string.format('UPDATE player_vehicles SET %s WHERE id = ?', table.concat(crumbs, ',')), placeholders
+end
+
+---@param options SaveVehicleOptions
+---@return boolean success, ErrorResult? errorResult
+local function saveVehicle(vehicle, options)
+    local vehicleId = Entity(vehicle).state.vehicleid or getVehicleIdByPlate(GetVehicleNumberPlateText(vehicle))
+    if not vehicleId then
+        return false, {
+            code = 'not_owned',
+            message = 'vehicle does not have a vehicleId and plate is not in the player_vehicles table'
+        }
+    end
+
+    local query, placeholders = buildSaveVehicleQuery(vehicleId, options)
+    MySQL.update.await(query, placeholders)
+    return true
+end
+
+exports('SaveVehicle', saveVehicle)


### PR DESCRIPTION
I'm not convinced this is the best solution. Putting this up for feedback.

Some write or multiple write exports are needed to replace existing direct SQL calls to player_vehicles table. qb-policejob /depot command is the hero use case here as it needs to do a few different things:
- set the garage to the impound
- set the depot price
- save the current vehicle properties
- change the vehicle state

Alternatives:
- Make a specific impound export
- Have this export live in qbx_garages
- Use multiple targeted exports in sequence to do the different parts (one to update props, another to set depot price, etc)