### PR TITLE
fix: citizenid handling in SQL update

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -176,7 +176,7 @@ local function setPlayerVehicleOwner(vehicleId, citizenid)
             message = 'a changeVehicleOwner event hook cancelled this operation'
         }
     end
-    MySQL.update.await('UPDATE player_vehicles SET citizenid = ?, license = (SELECT license FROM players WHERE citizenid = @citizenid) WHERE id = @id', {
+    MySQL.update.await('UPDATE player_vehicles SET citizenid = @citizenid, license = (SELECT license FROM players WHERE citizenid = @citizenid) WHERE id = @id', {
         citizenid = citizenid,
         id = vehicleId
     })


### PR DESCRIPTION
## Description

Was randomly trying the `/admincar` command from [qbx_adminmenu](https://github.com/Qbox-project/qbx_adminmenu) and found out that the override functionality doesn't save the citizenid properly, instead saves it as `NULL` 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
